### PR TITLE
Make installable by `pip install git+`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.8.4
     hooks:
       - id: flake8

--- a/pandas_decimal/array.py
+++ b/pandas_decimal/array.py
@@ -180,9 +180,7 @@ class DecimalExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         return self[indices]
 
     def copy(self):
-        return type(self)(
-            np.copy(self._data / 10**self.dtype.decimal_places), dtype=self._dtype
-        )
+        return type(self).from_internal(np.copy(self._data), dtype=self._dtype)
 
     @classmethod
     def _concat_same_type(cls, to_concat):

--- a/pandas_decimal/array.py
+++ b/pandas_decimal/array.py
@@ -218,28 +218,28 @@ class DecimalExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         )
 
     def max(self, **kwargs):
-        kwargs.pop("min_count")
-        kwargs.pop("skipna")
+        kwargs.pop("min_count", None)
+        kwargs.pop("skipna", None)
         return self._data.max(**kwargs) / 10**self.dtype.decimal_places
 
     def min(self, **kwargs):
-        kwargs.pop("min_count")
-        kwargs.pop("skipna")
+        kwargs.pop("min_count", None)
+        kwargs.pop("skipna", None)
         return self._data.min(**kwargs) / 10**self.dtype.decimal_places
 
     def mean(self, **kwargs):
-        kwargs.pop("min_count")
-        kwargs.pop("skipna")
+        kwargs.pop("min_count", None)
+        kwargs.pop("skipna", None)
         return self._data.mean(**kwargs) / 10**self.dtype.decimal_places
 
     def std(self, **kwargs):
-        kwargs.pop("min_count")
-        kwargs.pop("skipna")
+        kwargs.pop("min_count", None)
+        kwargs.pop("skipna", None)
         return self._data.std(**kwargs) / 10**self.dtype.decimal_places
 
     def sum(self, **kwargs):
-        kwargs.pop("min_count")
-        kwargs.pop("skipna")
+        kwargs.pop("min_count", None)
+        kwargs.pop("skipna", None)
         return self._data.sum(**kwargs) / 10**self.dtype.decimal_places
 
 

--- a/pandas_decimal/array.py
+++ b/pandas_decimal/array.py
@@ -180,7 +180,9 @@ class DecimalExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         return self[indices]
 
     def copy(self):
-        return type(self)(np.copy(self._data), dtype=self._dtype)
+        return type(self)(
+            np.copy(self._data / 10**self.dtype.decimal_places), dtype=self._dtype
+        )
 
     @classmethod
     def _concat_same_type(cls, to_concat):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,4 +33,4 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["pandas_decimal*"]
+include = ["pandas_decimal"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,6 @@ requires = [
   "wheel",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["pandas_decimal*"]

--- a/tests/test_instantiation.py
+++ b/tests/test_instantiation.py
@@ -35,18 +35,21 @@ def test_instantiation_int_values_are_correct_and_internally_correct(test_degree
     series = pd.Series(original, dtype=f"decimal[{test_degree}]")
     assert all(x * factor == y for x, y in zip(original, series.values._data))
 
+
 @pytest.mark.parametrize("test_degree", [1, 2, 3])
 def test_instantiation_float_values_are_correct_and_not_morphed(test_degree):
-    original = [.1, .2, .3]
+    original = [0.1, 0.2, 0.3]
     series = pd.Series(original, dtype=f"decimal[{test_degree}]")
     assert all(np.isclose(x, y) for x, y in zip(original, series))
 
 
 @pytest.mark.parametrize("test_degree", [1, 2, 3])
 def test_instantiation_float_values_are_correct_and_internally_correct(test_degree):
-    original = [.1, .2, .3]
+    original = [0.1, 0.2, 0.3]
     factor = int(10**test_degree)
     series = pd.Series(original, dtype=f"decimal[{test_degree}]")
     assert all(x * factor == y for x, y in zip(original, series.values._data))
 
-# TODO: Make tests that test what to do when decimals are truncated and their correct behavior
+
+# TODO: Make tests that test what to do when decimals are truncated
+# and their correct behavior


### PR DESCRIPTION
I wanted to try out the module with: `python -m pip install git+https://github.com/martindurant/pandas-decimal`, but got the following error.  This is fixed by adding `[tool.setuptools.packages.find]` to `pyproject.toml`. 

Also, I changed flake8 to the github repo and ran `pre-commit run --all-files`. 


``` python-traceback
❯ python -m pip install git+https://github.com/martindurant/pandas-decimal
Collecting git+https://github.com/martindurant/pandas-decimal
  Cloning https://github.com/martindurant/pandas-decimal to /tmp/pip-req-build-79x1j4gq
  Running command git clone --filter=blob:none --quiet https://github.com/martindurant/pandas-decimal /tmp/pip-req-build-79x1j4gq
  Resolved https://github.com/martindurant/pandas-decimal to commit 8b1bcd8957f9a80441b373b957505be32cb464c8
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [16 lines of output]
      /tmp/pip-build-env-lzwhwyiv/overlay/lib/python3.10/site-packages/setuptools/config/expand.py:144: UserWarning: File '/tmp/pip-req-build-79x1j4gq/LICENCE' cannot be found
        warnings.warn(f"File {path!r} cannot be found")
      error: Multiple top-level packages discovered in a flat-layout: ['notebooks', 'pandas_decimal'].
      
      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.
      
      If you are trying to create a single distribution with multiple packages
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:
      
      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names
      
      To find more information, look for "package discovery" on setuptools docs.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```